### PR TITLE
Add an option to dynamically add custom span attribute

### DIFF
--- a/foxtrace.go
+++ b/foxtrace.go
@@ -59,8 +59,13 @@ func (t *Tracer) Trace(next fox.HandlerFunc) fox.HandlerFunc {
 
 		ctx := t.cfg.propagator.Extract(req.Context(), t.cfg.carrier(req))
 
+		attributes := httpconv.ServerRequest(t.service, req)
+		if t.cfg.attrsFn != nil {
+			attributes = append(attributes, t.cfg.attrsFn(req)...)
+		}
+
 		opts := []trace.SpanStartOption{
-			trace.WithAttributes(httpconv.ServerRequest(t.service, req)...),
+			trace.WithAttributes(attributes...),
 			trace.WithSpanKind(trace.SpanKindServer),
 		}
 

--- a/foxtrace_test.go
+++ b/foxtrace_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tigerwill90/fox"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"net/http"
@@ -78,6 +79,38 @@ func TestPropagationWithCustomPropagators(t *testing.T) {
 	router := fox.New()
 	mw := New("foobar", WithTracerProvider(provider), WithPropagators(b3))
 	err := router.Handle(http.MethodGet, "/user/:id", mw.Trace(func(c fox.Context) {
+		span := trace.SpanFromContext(c.Request().Context())
+		assert.Equal(t, sc.TraceID(), span.SpanContext().TraceID())
+		assert.Equal(t, sc.SpanID(), span.SpanContext().SpanID())
+	}))
+
+	require.NoError(t, err)
+	router.ServeHTTP(w, r)
+}
+
+func TestWithSpanAttributes(t *testing.T) {
+	provider := trace.NewNoopTracerProvider()
+	otel.SetTextMapPropagator(b3prop.New())
+
+	r := httptest.NewRequest("GET", "/user/123?foo=bar", nil)
+	w := httptest.NewRecorder()
+
+	ctx := context.Background()
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{0x01},
+		SpanID:  trace.SpanID{0x01},
+	})
+	ctx = trace.ContextWithRemoteSpanContext(ctx, sc)
+	ctx, _ = provider.Tracer(tracerName).Start(ctx, "test")
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(r.Header))
+
+	router := fox.New()
+	mw := New("foobar", WithTracerProvider(provider), WithSpanAttributes(func(r *http.Request) []attribute.KeyValue {
+		attrs := make([]attribute.KeyValue, 1)
+		attrs[0] = attribute.String("http.target", r.URL.String())
+		return attrs
+	}))
+	err := router.Handle(http.MethodGet, "/user/{id}", mw.Trace(func(c fox.Context) {
 		span := trace.SpanFromContext(c.Request().Context())
 		assert.Equal(t, sc.TraceID(), span.SpanContext().TraceID())
 		assert.Equal(t, sc.SpanID(), span.SpanContext().SpanID())

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.3
-	github.com/tigerwill90/fox v0.9.1
+	github.com/tigerwill90/fox v0.9.3
 	go.opentelemetry.io/contrib/propagators/b3 v1.17.0
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.3
-	github.com/tigerwill90/fox v0.9.3
+	github.com/tigerwill90/fox v0.9.4
 	go.opentelemetry.io/contrib/propagators/b3 v1.17.0
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gt
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tigerwill90/fox v0.9.1 h1:RKRpQhv5uNyqgNu+9e2EnOs9XEBrk8AvVccsmHUQBs4=
 github.com/tigerwill90/fox v0.9.1/go.mod h1:frBRK49d4TXcELy3911opGU3RZQSUq++BHQUwhykpQw=
+github.com/tigerwill90/fox v0.9.3 h1:iDtNIQRPpqvIjSljvX6UVO2XIFtIqYPiOXGwCjuq3iM=
+github.com/tigerwill90/fox v0.9.3/go.mod h1:frBRK49d4TXcELy3911opGU3RZQSUq++BHQUwhykpQw=
 go.opentelemetry.io/contrib/propagators/b3 v1.17.0 h1:ImOVvHnku8jijXqkwCSyYKRDt2YrnGXD4BbhcpfbfJo=
 go.opentelemetry.io/contrib/propagators/b3 v1.17.0/go.mod h1:IkfUfMpKWmynvvE0264trz0sf32NRTZL4nuAN9AbWRc=
 go.opentelemetry.io/otel v1.16.0 h1:Z7GVAX/UkAXPKsy94IU+i6thsQS4nb7LviLpnaNeW8s=

--- a/go.sum
+++ b/go.sum
@@ -16,10 +16,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/tigerwill90/fox v0.9.1 h1:RKRpQhv5uNyqgNu+9e2EnOs9XEBrk8AvVccsmHUQBs4=
-github.com/tigerwill90/fox v0.9.1/go.mod h1:frBRK49d4TXcELy3911opGU3RZQSUq++BHQUwhykpQw=
-github.com/tigerwill90/fox v0.9.3 h1:iDtNIQRPpqvIjSljvX6UVO2XIFtIqYPiOXGwCjuq3iM=
-github.com/tigerwill90/fox v0.9.3/go.mod h1:frBRK49d4TXcELy3911opGU3RZQSUq++BHQUwhykpQw=
+github.com/tigerwill90/fox v0.9.4 h1:uqZqwSDbso1gs1U7kw4Y6srXOLFNgMjKQUNIZWr5kak=
+github.com/tigerwill90/fox v0.9.4/go.mod h1:frBRK49d4TXcELy3911opGU3RZQSUq++BHQUwhykpQw=
 go.opentelemetry.io/contrib/propagators/b3 v1.17.0 h1:ImOVvHnku8jijXqkwCSyYKRDt2YrnGXD4BbhcpfbfJo=
 go.opentelemetry.io/contrib/propagators/b3 v1.17.0/go.mod h1:IkfUfMpKWmynvvE0264trz0sf32NRTZL4nuAN9AbWRc=
 go.opentelemetry.io/otel v1.16.0 h1:Z7GVAX/UkAXPKsy94IU+i6thsQS4nb7LviLpnaNeW8s=


### PR DESCRIPTION
This PR introduces a new option that allows customization of span attributes based on the incoming request.

```go
mw := New("foobar", WithTracerProvider(provider), WithSpanAttributes(func(r *http.Request) []attribute.KeyValue {
    attrs := make([]attribute.KeyValue, 1)
    attrs[0] = attribute.String("http.target", r.URL.String())
    return attrs
}))
```

This enhancement provides the ability to include non-standard attributes, such as `http.target`, in the span information. This can be particularly useful for capturing additional contextual information specific to the request.