### PR TITLE
Fix serverClientIp function that panic on non RouteHandler scope.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	github.com/tigerwill90/fox v0.20.0
+	github.com/tigerwill90/fox v0.20.1
 	go.opentelemetry.io/contrib/propagators/b3 v1.34.0
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tigerwill90/fox v0.20.0 h1:bILdreDBwEhEoUdH3w7EL7L9yLkgd/X+oRP2o57iK2I=
-github.com/tigerwill90/fox v0.20.0/go.mod h1:j86+yFuBav3kL1V5vSV71RyN5Y5Lqu7zqxk8VG5e+CY=
+github.com/tigerwill90/fox v0.20.1 h1:rPQvN0FmyY/YlFgW/UJz5mwmofu1dAbP6DMGIuqCU8A=
+github.com/tigerwill90/fox v0.20.1/go.mod h1:j86+yFuBav3kL1V5vSV71RyN5Y5Lqu7zqxk8VG5e+CY=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/propagators/b3 v1.34.0 h1:9pQdCEvV/6RWQmag94D6rhU+A4rzUhYBEJ8bpscx5p8=

--- a/internal/clientip/clientip.go
+++ b/internal/clientip/clientip.go
@@ -1,0 +1,50 @@
+package clientip
+
+import (
+	"github.com/tigerwill90/fox"
+	"github.com/tigerwill90/fox/clientip"
+	"net"
+)
+
+var DefaultResolver = newChain(
+	must(clientip.NewLeftmostNonPrivate(clientip.XForwardedForKey, 15)),
+	must(clientip.NewLeftmostNonPrivate(clientip.ForwardedKey, 15)),
+	must(clientip.NewSingleIPHeader(fox.HeaderXRealIP)),
+	must(clientip.NewSingleIPHeader(fox.HeaderCFConnectionIP)),
+	must(clientip.NewSingleIPHeader(fox.HeaderTrueClientIP)),
+	must(clientip.NewSingleIPHeader(fox.HeaderFastClientIP)),
+	must(clientip.NewSingleIPHeader(fox.HeaderXAzureClientIP)),
+	must(clientip.NewSingleIPHeader(fox.HeaderXAppengineRemoteAddr)),
+	must(clientip.NewSingleIPHeader(fox.HeaderFlyClientIP)),
+	must(clientip.NewSingleIPHeader(fox.HeaderXAzureSocketIP)),
+	clientip.NewRemoteAddr(),
+)
+
+type chain struct {
+	resolvers []fox.ClientIPResolver
+}
+
+func newChain(resolvers ...fox.ClientIPResolver) chain {
+	return chain{resolvers: resolvers}
+}
+
+// ClientIP try to derive the client IP using this resolver chain.
+func (s chain) ClientIP(c fox.Context) (*net.IPAddr, error) {
+	var lastErr error
+	for _, sub := range s.resolvers {
+		ipAddr, err := sub.ClientIP(c)
+		if err == nil {
+			return ipAddr, nil
+		}
+		lastErr = err
+	}
+
+	return nil, lastErr
+}
+
+func must(resolver fox.ClientIPResolver, err error) fox.ClientIPResolver {
+	if err != nil {
+		panic(err)
+	}
+	return resolver
+}

--- a/option.go
+++ b/option.go
@@ -2,7 +2,6 @@ package otelfox
 
 import (
 	"github.com/tigerwill90/fox"
-	"github.com/tigerwill90/fox/clientip"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
@@ -50,19 +49,6 @@ func defaultConfig() *config {
 		carrier: func(r *http.Request) propagation.TextMapCarrier {
 			return propagation.HeaderCarrier(r.Header)
 		},
-		resolver: clientip.NewChain(
-			must(clientip.NewLeftmostNonPrivate(clientip.XForwardedForKey, 15)),
-			must(clientip.NewLeftmostNonPrivate(clientip.ForwardedKey, 15)),
-			must(clientip.NewSingleIPHeader(fox.HeaderCFConnectionIP)),
-			must(clientip.NewSingleIPHeader(fox.HeaderTrueClientIP)),
-			must(clientip.NewSingleIPHeader(fox.HeaderFastClientIP)),
-			must(clientip.NewSingleIPHeader(fox.HeaderXAzureClientIP)),
-			must(clientip.NewSingleIPHeader(fox.HeaderXAzureSocketIP)),
-			must(clientip.NewSingleIPHeader(fox.HeaderXAppengineRemoteAddr)),
-			must(clientip.NewSingleIPHeader(fox.HeaderFlyClientIP)),
-			must(clientip.NewSingleIPHeader(fox.HeaderXRealIP)),
-			clientip.NewRemoteAddr(),
-		),
 	}
 }
 
@@ -127,18 +113,12 @@ func WithSpanAttributes(fn SpanAttributesFunc) Option {
 
 // WithClientIPResolver sets a custom resolver to determine the client IP address.
 // This is for advanced use case, must user should configure the resolver with Fox's router option using
-// [fox.WithClientIPResolver].
+// [fox.WithClientIPResolver]. Note that setting a resolver here takes priority over any resolver configured
+// globally or at the route level in Fox.
 func WithClientIPResolver(resolver fox.ClientIPResolver) Option {
 	return optionFunc(func(c *config) {
 		if resolver != nil {
 			c.resolver = resolver
 		}
 	})
-}
-
-func must(resolver fox.ClientIPResolver, err error) fox.ClientIPResolver {
-	if err != nil {
-		panic(err)
-	}
-	return resolver
 }

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package otelfox
 
 import "fmt"
 
-const version = "v0.20.0"
+const version = "v0.20.1"
 
 var semver = fmt.Sprintf("semver:%s", version)
 


### PR DESCRIPTION
### Description

This PR addresses a bug in the `serverClientIP` function that caused a panic when handling requests with the `notFound`, `noMethod`, or `autoOption` handlers. Additionally, it enhances the performance of the default clientip resolver for improved efficiency.